### PR TITLE
✨ Implement AI Resume Setup Page with react-hook-form

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,1 +1,1 @@
-cd frontend && npx lint-staged
+cd frontend && npx lint-staged --no-stash

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "next": "15.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.57.0",
         "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
@@ -5070,6 +5071,21 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "next": "15.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.57.0",
     "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {

--- a/frontend/src/apis/apiClient.ts
+++ b/frontend/src/apis/apiClient.ts
@@ -1,43 +1,17 @@
 import axios, { AxiosRequestConfig } from "axios";
 
-const isDevelopment = process.env.NODE_ENV === "development";
-
-const getBaseURL = () => {
-  if (isDevelopment) {
-    return process.env.NEXT_PUBLIC_DEV_API_URL;
-  }
-  return process.env.NEXT_PUBLIC_PROD_API_URL;
-};
-
 const defaultConfig: AxiosRequestConfig = {
-  baseURL: getBaseURL(),
-  timeout: 10000,
-  headers: {
-    Accept: "application/json",
-    "Content-Type": "application/json",
-  },
+  baseURL: "http://18.220.15.239:8000",
+  headers: { Accept: "application/json" },
 };
 
-export const createApi = (config?: AxiosRequestConfig) => {
+export function createCustomAxios(config?: AxiosRequestConfig) {
   return axios.create({
     ...defaultConfig,
     ...config,
+    headers: {
+      ...defaultConfig.headers,
+      ...(config?.headers || {}),
+    },
   });
-};
-
-// 기본 API 인스턴스
-export const API = createApi();
-
-// 긴 시간이 필요한 요청을 위한 인스턴스 (예: AI 작업)
-export const LongTimeoutAPI = createApi({
-  timeout: 480000, // 8분
-});
-
-// 파일 업로드용 인스턴스
-export const UploadAPI = createApi({
-  timeout: 60000,
-  headers: {
-    ...defaultConfig.headers,
-    "Content-Type": "multipart/form-data",
-  },
-});
+}

--- a/frontend/src/apis/fetchAIResume.ts
+++ b/frontend/src/apis/fetchAIResume.ts
@@ -1,0 +1,12 @@
+import { AIResumeResponse, InputResumeProfileRequest } from "@/types/resume";
+import { createCustomAxios } from "./apiClient";
+
+export async function fetchAIResume(
+  input: InputResumeProfileRequest,
+): Promise<AIResumeResponse> {
+  const { data } = await createCustomAxios().post<AIResumeResponse>(
+    "/api/profile",
+    input,
+  );
+  return data;
+}

--- a/frontend/src/app/resume/start/components/ActivityLinksField.tsx
+++ b/frontend/src/app/resume/start/components/ActivityLinksField.tsx
@@ -1,0 +1,55 @@
+import TextField from "@/components/Field/TextField";
+import Button from "@/components/Button/Button";
+import Icon from "@/components/Icon/Icon";
+import IconButton from "@/components/IconButton/IconButton";
+
+interface ActivityLinksFieldProps {
+  activityLinks: string[];
+  onChange: (activityLinks: string[]) => void;
+}
+
+export default function ActivityLinksField({
+  activityLinks,
+  onChange,
+}: ActivityLinksFieldProps) {
+  const addActivityLink = () => {
+    onChange([...activityLinks, ""]);
+  };
+
+  const removeActivityLink = (index: number) => {
+    onChange(activityLinks.filter((_, i) => i !== index));
+  };
+
+  const updateActivityLink = (index: number, value: string) => {
+    const newLinks = [...activityLinks];
+    newLinks[index] = value;
+    onChange(newLinks);
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="block body-s-regular font-medium text-gray-700">
+        활동 링크 <span className="text-red-500">*</span>
+      </label>
+      {activityLinks.map((value, index) => (
+        <div key={index} className="flex gap-2 items-center">
+          <TextField
+            value={value}
+            onChange={(e) => updateActivityLink(index, e.target.value)}
+            placeholder="ex. https://github.com/example1"
+          />
+          <IconButton
+            startIcon={<Icon icon="Delete" size={16} />}
+            onClick={() => removeActivityLink(index)}
+          />
+        </div>
+      ))}
+      <Button
+        onClick={addActivityLink}
+        className="mt-2 px-4 py-2 button-s-medium text-blue-500 hover:text-blue-700 border border-blue-500 rounded-md"
+      >
+        활동 링크 추가
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/app/resume/start/components/EducationField.tsx
+++ b/frontend/src/app/resume/start/components/EducationField.tsx
@@ -1,0 +1,55 @@
+import TextField from "@/components/Field/TextField";
+import Button from "@/components/Button/Button";
+import Icon from "@/components/Icon/Icon";
+import IconButton from "@/components/IconButton/IconButton";
+
+interface EducationFieldProps {
+  education: string[];
+  onChange: (education: string[]) => void;
+}
+
+export default function EducationField({
+  education,
+  onChange,
+}: EducationFieldProps) {
+  const addEducation = () => {
+    onChange([...education, ""]);
+  };
+
+  const removeEducation = (index: number) => {
+    onChange(education.filter((_, i) => i !== index));
+  };
+
+  const updateEducation = (index: number, value: string) => {
+    const newEducation = [...education];
+    newEducation[index] = value;
+    onChange(newEducation);
+  };
+
+  return (
+    <div className="space-y-2">
+      <label className="block body-s-regular font-medium text-gray-700">
+        학력
+      </label>
+      {education.map((value, index) => (
+        <div key={index} className="flex gap-2 items-center">
+          <TextField
+            value={value}
+            onChange={(e) => updateEducation(index, e.target.value)}
+            placeholder="ex. 중앙대학교"
+          />
+          <IconButton
+            startIcon={<Icon icon="Delete" size={16} />}
+            onClick={() => removeEducation(index)}
+          />
+        </div>
+      ))}
+      <Button
+        onClick={addEducation}
+        className="mt-2 px-4 py-2 button-s-medium text-blue-500 hover:text-blue-700 border border-blue-500 rounded-md"
+      >
+        학력 추가
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/app/resume/start/components/RequiredTextField.tsx
+++ b/frontend/src/app/resume/start/components/RequiredTextField.tsx
@@ -1,0 +1,46 @@
+import TextField from "@/components/Field/TextField";
+import { UseFormRegister, FieldErrors } from "react-hook-form";
+import type { InputResumeProfileRequest } from "@/types/resume";
+
+type RequiredFieldKeys = "name" | "desired_role";
+type OptionalFieldKeys = "english_name" | "contact";
+
+interface RequiredTextFieldProps {
+  id: string;
+  label: string;
+  placeholder: string;
+  register: UseFormRegister<InputResumeProfileRequest>;
+  errors: FieldErrors<InputResumeProfileRequest>;
+  name: RequiredFieldKeys | OptionalFieldKeys;
+  required?: boolean;
+}
+
+export default function RequiredTextField({
+  id,
+  label,
+  placeholder,
+  register,
+  errors,
+  name,
+  required = true,
+}: RequiredTextFieldProps) {
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor={id}
+        className="block body-s-regular font-medium text-gray-700"
+      >
+        {label} {required && <span className="text-red-500">*</span>}
+      </label>
+      <TextField
+        id={id}
+        type="text"
+        placeholder={placeholder}
+        {...register(name, { required })}
+      />
+      {errors[name] && required && (
+        <p className="caption-m-regular text-red-500">필수 입력</p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/resume/start/components/ResumeForm.tsx
+++ b/frontend/src/app/resume/start/components/ResumeForm.tsx
@@ -1,0 +1,153 @@
+import { useForm } from "react-hook-form";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Section from "@/components/Field/Section";
+import Button from "@/components/Button/Button";
+import { InputResumeProfileRequest, AIResumeResponse } from "@/types/resume";
+import { useSubmitAIResumeMutation } from "@/hooks/queries/useSubmitAIResumeMutation";
+import { useLocalStorageObject } from "@/hooks/useLocalStorageObject";
+import RequiredTextField from "./RequiredTextField";
+import EducationField from "./EducationField";
+import ActivityLinksField from "./ActivityLinksField";
+
+export default function ResumeForm() {
+  const router = useRouter();
+  const [education, setEducation] = useState<string[]>([""]);
+  const [activityLinks, setActivityLinks] = useState<string[]>([""]);
+  const [error, setError] = useState<string | null>(null);
+  const [activityLinksError, setActivityLinksError] = useState<string | null>(
+    null,
+  );
+
+  const { setItem: setResume } =
+    useLocalStorageObject<AIResumeResponse>("resumeData");
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<InputResumeProfileRequest>({
+    defaultValues: {
+      activity_links: [""],
+    },
+  });
+
+  const { mutate, isPending } = useSubmitAIResumeMutation();
+  const onSuccess = (data: AIResumeResponse) => {
+    setResume(data);
+    router.push("/resume/edit");
+  };
+  const onError = (e: Error) => {
+    setError(e.message);
+  };
+
+  const validateActivityLinks = () => {
+    const hasEmptyLink = activityLinks.some((link) => link.trim() === "");
+    if (hasEmptyLink) {
+      setActivityLinksError("활동 링크를 모두 입력해주세요");
+      return false;
+    }
+    setActivityLinksError(null);
+    return true;
+  };
+
+  const onInvalid = () => {
+    validateActivityLinks();
+  };
+
+  const onSubmit = (formData: InputResumeProfileRequest) => {
+    if (!validateActivityLinks()) {
+      return;
+    }
+
+    const payload: InputResumeProfileRequest = {
+      ...formData,
+      education,
+      activity_links: activityLinks,
+    };
+    mutate(payload, { onSuccess, onError });
+  };
+
+  return (
+    <Section
+      title="기본 정보"
+      description="기본 정보를 입력하면 AI가 이력서를 생성해줍니다."
+      className="max-w-[800px] w-full mb-5"
+    >
+      <form
+        onSubmit={handleSubmit(onSubmit, onInvalid)}
+        className="space-y-6 w-full"
+      >
+        <RequiredTextField
+          id="name"
+          label="이름"
+          placeholder="ex. 홍길동"
+          register={register}
+          errors={errors}
+          name="name"
+          required={true}
+        />
+
+        <RequiredTextField
+          id="english_name"
+          label="영문 이름"
+          placeholder="ex. GilDong Hong"
+          register={register}
+          errors={errors}
+          name="english_name"
+          required={false}
+        />
+
+        <EducationField education={education} onChange={setEducation} />
+
+        <RequiredTextField
+          id="desired_role"
+          label="희망 직무"
+          placeholder="ex. 프론트엔드 엔지니어"
+          register={register}
+          errors={errors}
+          name="desired_role"
+          required={true}
+        />
+
+        <RequiredTextField
+          id="contact"
+          label="연락처"
+          placeholder="010-1234-5678"
+          register={register}
+          errors={errors}
+          name="contact"
+          required={false}
+        />
+
+        <div className="space-y-2">
+          <ActivityLinksField
+            activityLinks={activityLinks}
+            onChange={setActivityLinks}
+          />
+          {activityLinksError && (
+            <p className="caption-m-regular text-red-500">
+              {activityLinksError}
+            </p>
+          )}
+        </div>
+
+        <Button
+          variant="primary"
+          fullWidth
+          type="submit"
+          className="p-4 mt-4"
+          disabled={isPending}
+        >
+          {isPending ? "생성 중..." : "AI 이력서 결과 받기"}
+        </Button>
+      </form>
+
+      {error && (
+        <div className="body-m-regular mt-4 p-4 bg-red-50 text-red-500 rounded-md">
+          {error}: 에러가 발생했습니다. 다시 시도해주세요.
+        </div>
+      )}
+    </Section>
+  );
+}

--- a/frontend/src/app/resume/start/page.tsx
+++ b/frontend/src/app/resume/start/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import DefaultLayout from "@/components/layout/DefaultLayout";
+import ResumeForm from "./components/ResumeForm";
+
+export default function StartPage() {
+  return (
+    <DefaultLayout>
+      <div className="w-full py-8 flex flex-col items-center justify-center">
+        <h2 className="text-4xl sm:text-5xl lg:text-6xl text-gray-900 leading-tight font-bold text-center mb-8">
+          AI 생성을 위한 기본 정보를 입력하세요
+        </h2>
+        <ResumeForm />
+      </div>
+    </DefaultLayout>
+  );
+}

--- a/frontend/src/components/Field/Section.tsx
+++ b/frontend/src/components/Field/Section.tsx
@@ -4,18 +4,25 @@ interface SectionProps {
   title: string;
   description: string;
   children: React.ReactNode;
+  className?: string;
   ref?: React.Ref<HTMLDivElement>;
 }
 
-function Section({ title, description, children, ref }: SectionProps) {
+function Section({
+  title,
+  description,
+  children,
+  ref,
+  className,
+}: SectionProps) {
   return (
-    <section ref={ref}>
-      <div className="bg-white rounded-2xl shadow p-7 mx-auto w-full">
-        <h2 className="mt-4 text-xl font-semibold text-gray-800">{title}</h2>
+    <section ref={ref} className={className}>
+      <div className="bg-white rounded-2xl shadow p-7 w-full">
+        <h2 className="mt-4 body-l-semibold text-gray-800">{title}</h2>
 
         <hr className="border-t-2 border-blue-500 my-4" />
 
-        <p className="mb-7 text-sm text-gray-500">{description}</p>
+        <p className="mb-7 caption-m-regular text-gray-500">{description}</p>
 
         <div className="space-y-5">{children}</div>
       </div>

--- a/frontend/src/components/Field/TextField.tsx
+++ b/frontend/src/components/Field/TextField.tsx
@@ -1,14 +1,14 @@
-interface TextFieldProps {
-  id: string;
-  type: string;
-  value: string;
+interface TextFieldProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  id?: string;
+  type?: string;
+  value?: string;
   placeholder?: string;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
 function TextField({
   id,
-  type,
+  type = "text",
   value,
   placeholder,
   onChange,

--- a/frontend/src/components/IconButton/IconButton.tsx
+++ b/frontend/src/components/IconButton/IconButton.tsx
@@ -1,7 +1,7 @@
 import { ButtonHTMLAttributes, ReactNode } from "react";
 import { type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/cn";
-import { buttonVariants } from "@/components/Button/Button.styles";
+import { buttonVariants } from "@/components/Button/buttonVariants";
 
 interface IconButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,

--- a/frontend/src/hooks/queries/useSubmitAIResumeMutation.ts
+++ b/frontend/src/hooks/queries/useSubmitAIResumeMutation.ts
@@ -1,0 +1,9 @@
+import { useMutation } from "@tanstack/react-query";
+import { fetchAIResume } from "@/apis/fetchAIResume";
+import { AIResumeResponse, InputResumeProfileRequest } from "@/types/resume";
+
+export function useSubmitAIResumeMutation() {
+  return useMutation<AIResumeResponse, Error, InputResumeProfileRequest>({
+    mutationFn: (data: InputResumeProfileRequest) => fetchAIResume(data),
+  });
+}

--- a/frontend/src/hooks/useLocalStorageObject.ts
+++ b/frontend/src/hooks/useLocalStorageObject.ts
@@ -1,0 +1,26 @@
+import { useCallback } from "react";
+
+export function useLocalStorageObject<T>(key: string) {
+  const setItem = useCallback(
+    (data: T) => {
+      localStorage.setItem(key, JSON.stringify(data));
+    },
+    [key],
+  );
+
+  const getItem = useCallback((): T | null => {
+    const raw = localStorage.getItem(key);
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  }, [key]);
+
+  const clearItem = useCallback(() => {
+    localStorage.removeItem(key);
+  }, [key]);
+
+  return { setItem, getItem, clearItem };
+}

--- a/frontend/src/types/resume.ts
+++ b/frontend/src/types/resume.ts
@@ -1,0 +1,58 @@
+export interface InputResumeProfileRequest {
+  name: string;
+  english_name: string;
+  education: string[];
+  desired_role: string;
+  contact: string;
+  activity_links: string[];
+}
+
+export type ProfileInfo = {
+  name: string;
+  english_name: string;
+  contact: string;
+  desired_role: string;
+  education: string[];
+  activity_links: string[];
+};
+
+export type ShortIntro = string;
+
+export type Skill = string;
+
+export type Project = {
+  name: string;
+  period: string;
+  role: string;
+  description: string;
+  honor: string;
+};
+
+export type Career = {
+  role: string;
+  company: string;
+  period: string;
+  description: string;
+};
+
+export type Education = {
+  name: string;
+  period: string;
+  description: string;
+};
+
+export type Club = {
+  name: string;
+  period: string;
+  description: string;
+};
+
+export interface AIResumeResponse {
+  profileInfo: ProfileInfo;
+  shortIntro: ShortIntro;
+  skills: Skill[];
+  projects: Project[];
+  career: Career[];
+  education: Education[];
+  clubs: Club[];
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 어떤 내용인지 간단히 설명해주세요 -->
유저의 기본정보를 입력받는 resume/start 페이지 구현

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] react-hook-form 의존성 추가: 폼 데이터 관리에 용이
- [x] api/apiClient: 옵션 오버라이딩이 가능하도록 형태 수정
- [x] api/fetchAIResume: ai 생성 api 패칭 함수
- [x] hooks/useLocalStorageObject: 로컬스토리지 set/get을 위한 커스텀훅
- [x] hooks/useSubmitAIResumeMutation: 비동기적인 패칭 상태를 관리하기 위한 리액트쿼리 훅
- [x] app/resume/start: 셋업 페이지를 이루는 컴포넌트

## 📸 스크린샷
<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->
![image](https://github.com/user-attachments/assets/372c4bc0-419f-4abe-9136-67efba25e25a)


## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes #13

## 📝 추가 설명

<!-- 추가로 설명이 필요한 사항이 있다면 작성해주세요 -->
