### PR TITLE
🐛 GET APIs

### DIFF
--- a/backend/sample_data/output_data.py
+++ b/backend/sample_data/output_data.py
@@ -1,6 +1,15 @@
 # LLM output sample data (실제로는 LLM에서 가져올 것)
 profile_data = {
-    "profileInfo": "홍길동 23세 백엔드",
+    "profileInfo": {
+    "name": "홍길동",
+    "english_name": "HONG GIL-DONG",
+    "educations": ["중앙대"],
+    "desired_role": "PM",
+    "contact": "010-1234-5678",
+    "activity_links": [
+      "https://cau.com"
+    ]
+  },
     "shortIntro": "책임감 있는 개발자입니다!",
     "skills": [
         "java 상",

--- a/backend/service.py
+++ b/backend/service.py
@@ -37,7 +37,7 @@ async def get_resume():
     return generate_profile()
 
 
-@app.get("/api/profileInfo", response_model=InputProfile, tags=["프로필"])
+@app.get("/api/profile/profileInfo", response_model=InputProfile, tags=["프로필"])
 async def get_profile():
     return profile_data["profileInfo"]
 

--- a/backend/service.py
+++ b/backend/service.py
@@ -54,12 +54,12 @@ async def get_skills():
 
 @app.get("/api/profile/career", response_model=List[Career], tags=["프로필"])
 async def get_career():
-    return profile_data["career"]
+    return profile_data["careers"]
 
 
 @app.get("/api/profile/education", response_model=List[Education], tags=["프로필"])
 async def get_education():
-    return profile_data["education"]
+    return profile_data["educations"]
 
 
 @app.get("/api/profile/clubs", response_model=List[Club], tags=["프로필"])

--- a/backend/service.py
+++ b/backend/service.py
@@ -37,9 +37,9 @@ async def get_resume():
     return generate_profile()
 
 
-@app.get("/api/profile", response_model=OutputProfile, tags=["프로필"])
+@app.get("/api/profileInfo", response_model=InputProfile, tags=["프로필"])
 async def get_profile():
-    return profile_data
+    return profile_data["profileInfo"]
 
 
 @app.get("/api/profile/projects", response_model=List[Project], tags=["프로필"])


### PR DESCRIPTION
## 📝 PR 개요

<!-- 이 PR이 어떤 내용인지 간단히 설명해주세요 -->

GET 
/api/profile
/api/education
/api/career

세 개의 GET API들이 500 error가 뜨는 에러 해결

## 🔍 변경 사항

<!-- 이 PR에서 변경된 내용을 상세히 설명해주세요 -->

- [x] /api/profile이 api/resume와 중복 기능을 하고 있어서 inputprofile 섹션을 리턴하는 api로 변경
- [x] /api/education의 리턴 값 필드 변경 (단수 복수 통일시 놓쳤던 거)
- [x] /api/career의 리턴 값 필드 변경 (단수 복수 통일시 놓쳤던 거)
- [x] mock data인 sample_data/output_data.py의 profileInfo의 형식을 inputprofile로 수정

## 🧪 테스트

<!-- 테스트한 내용을 설명해주세요 -->

- [x] 로컬 스웨거 통과

## 📸 스크린샷

<!-- UI 변경이 있는 경우, 스크린샷을 첨부해주세요 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호를 입력해주세요 -->

Closes #39 

## 📝 추가 설명

<!-- 추가로 설명이 필요한 사항이 있다면 작성해주세요 -->

프로필 태그 붙은 GET API들은 모두 mock data를 반환하는 것들입니다.
따라서 새롭게 생긴 /api/profileInfo 역시 mock data의 InputProfile을 반환하고 있습니다.